### PR TITLE
Composer json fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": ">=5.3.3",
         "silex/silex": "dev-master",
         "symfony/routing": "2.1.*",
-        "jms/serializer-bundle": ">=0.9"
+        "jms/serializer-bundle": "0.9.*"
     },
     "require-dev": {
         "doctrine/common": ">=2.1,<2.4-dev"


### PR DESCRIPTION
Need to lock serializer version down in json until provider can be updated for new serializer bundle dependancies. Also will need a new tag to 0.1.1 (I think).
