### PR TITLE
Fixed readme file for changed format of how JMS Serializer installes (no...

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -47,7 +47,7 @@ Registering
 $app = new Silex\Application();
 
 $app->register(new JMS\SerializerServiceProvider\SerializerServiceProvider(), array(
-    'serializer.src_directory' => 'path/to/vendor/jms/serializer-bundle/src',
+    'serializer.src_directory' => 'path/to/vendor/jms/serializer-bundle',
     'serializer.cache.directory' => 'path/to/cache'
 ));
 ```


### PR DESCRIPTION
...t sure how it changed but it did)

No longer needs 'src'
